### PR TITLE
unbreak type spec -- Obvious fix.

### DIFF
--- a/src/mini_s3.erl
+++ b/src/mini_s3.erl
@@ -77,7 +77,7 @@
               bucket_acl/0,
               location_constraint/0]).
 
--opaque config() :: record(config).
+-opaque config() :: #config{}.
 
 -type bucket_access_type() :: virtual_domain | path.
 


### PR DESCRIPTION
- erlc complains that type 'record(_)' does not exist.
- using '#config{}' allows compilation to continue, and enforces that type must be correct record.
